### PR TITLE
Cleanup and fixes for cluster_id change

### DIFF
--- a/inventory/byo/hosts.aep.example
+++ b/inventory/byo/hosts.aep.example
@@ -18,6 +18,9 @@ ansible_ssh_user=root
 # user must be configured for passwordless sudo
 #ansible_sudo=true
 
+# Debug level for all Atomic Enterprise components (Defaults to 2)
+debug_level=2
+
 # deployment type valid values are origin, online, atomic-enterprise, and openshift-enterprise
 deployment_type=atomic-enterprise
 

--- a/inventory/byo/hosts.aep_quickstart
+++ b/inventory/byo/hosts.aep_quickstart
@@ -1,0 +1,20 @@
+[OSEv3:children]
+masters
+nodes
+etcd
+lb
+
+[OSEv3:vars]
+ansible_ssh_user=root
+deployment_type=atomic-enterprise
+osm_use_cockpit=true
+
+[masters]
+ose3-master.example.com
+
+[nodes]
+ose3-master.example.com openshift_scheduleable=True
+
+[etcd]
+
+[lb]

--- a/inventory/byo/hosts.openstack
+++ b/inventory/byo/hosts.openstack
@@ -1,0 +1,37 @@
+# This is an example of a bring your own (byo) host inventory
+
+# Create an OSEv3 group that contains the masters and nodes groups
+[OSEv3:children]
+masters
+nodes
+etcd
+lb
+
+# Set variables common for all OSEv3 hosts
+[OSEv3:vars]
+ansible_ssh_user=cloud-user
+ansible_sudo=true
+
+# Debug level for all OpenShift components (Defaults to 2)
+debug_level=2
+
+deployment_type=openshift-enterprise
+
+openshift_additional_repos=[{'id': 'ose-3.1', 'name': 'ose-3.1', 'baseurl': 'http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7Server/x86_64/ose/3.1/os', 'enabled': 1, 'gpgcheck': 0}]
+
+openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'filename': '{{ openshift.common.config_base }}/htpasswd'}]
+
+#openshift_pkg_version=-3.0.0.0
+
+[masters]
+jdetiber-master.usersys.redhat.com openshift_public_hostname="{{ inventory_hostname }}" openshift_hostname="{{ ansible_default_ipv4.address }}"
+
+[etcd]
+jdetiber-etcd.usersys.redhat.com
+
+[lb]
+#ose3-lb-ansible.test.example.com
+
+[nodes]
+jdetiber-master.usersys.redhat.com openshift_public_hostname="{{ inventory_hostname }}" openshift_hostname="{{ ansible_default_ipv4.address }}"
+jdetiber-node[1:2].usersys.redhat.com openshift_public_hostname="{{ inventory_hostname }}" openshift_hostname="{{ ansible_default_ipv4.address }}" openshift_node_labels="{'region': 'primary', 'zone': 'default'}"

--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -18,6 +18,9 @@ ansible_ssh_user=root
 # user must be configured for passwordless sudo
 #ansible_sudo=true
 
+# Debug level for all OpenShift components (Defaults to 2)
+debug_level=2
+
 # deployment type valid values are origin, online, atomic-enterprise and openshift-enterprise
 deployment_type=origin
 

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -18,6 +18,9 @@ ansible_ssh_user=root
 # user must be configured for passwordless sudo
 #ansible_sudo=true
 
+# Debug level for all OpenShift components (Defaults to 2)
+debug_level=2
+
 # deployment type valid values are origin, online, atomic-enterprise, and openshift-enterprise
 deployment_type=openshift-enterprise
 

--- a/playbooks/aws/openshift-cluster/cluster_hosts.yml
+++ b/playbooks/aws/openshift-cluster/cluster_hosts.yml
@@ -1,16 +1,19 @@
 ---
-etcd_hosts:   "{{ (groups['tag_host-type_etcd']|default([]))
-                    | intersect((groups['tag_clusterid_' ~ cluster_id]|default([])))
-                    | intersect((groups['tag_environment_' ~ cluster_env]|default([]))) }}"
+g_etcd_hosts:   "{{ (groups['tag_host-type_etcd']|default([]))
+                     | intersect((groups['tag_clusterid_' ~ cluster_id]|default([])))
+                     | intersect((groups['tag_environment_' ~ cluster_env]|default([]))) }}"
 
-lb_hosts:     "{{ (groups['tag_host-type_lb']|default([]))
-                    | intersect((groups['tag_clusterid_' ~ cluster_id]|default([])))
-                    | intersect((groups['tag_environment_' ~ cluster_env]|default([]))) }}"
+g_lb_hosts:     "{{ (groups['tag_host-type_lb']|default([]))
+                     | intersect((groups['tag_clusterid_' ~ cluster_id]|default([])))
+                     | intersect((groups['tag_environment_' ~ cluster_env]|default([]))) }}"
 
-master_hosts: "{{ (groups['tag_host-type_master']|default([]))
-                    | intersect((groups['tag_clusterid_' ~ cluster_id]|default([])))
-                    | intersect((groups['tag_environment_' ~ cluster_env]|default([]))) }}"
+g_master_hosts: "{{ (groups['tag_host-type_master']|default([]))
+                     | intersect((groups['tag_clusterid_' ~ cluster_id]|default([])))
+                     | intersect((groups['tag_environment_' ~ cluster_env]|default([]))) }}"
 
-node_hosts:   "{{ (groups['tag_host-type_node']|default([]))
-                    | intersect((groups['tag_clusterid_' ~ cluster_id]|default([])))
-                    | intersect((groups['tag_environment_' ~ cluster_env]|default([]))) }}"
+g_node_hosts:   "{{ (groups['tag_host-type_node']|default([]))
+                     | intersect((groups['tag_clusterid_' ~ cluster_id]|default([])))
+                     | intersect((groups['tag_environment_' ~ cluster_env]|default([]))) }}"
+
+g_all_hosts:    "{{ g_master_hosts | union(g_node_hosts) | union(g_etcd_hosts)
+                    | union(g_lb_hosts) | default([]) }}"

--- a/playbooks/aws/openshift-cluster/config.yml
+++ b/playbooks/aws/openshift-cluster/config.yml
@@ -1,31 +1,14 @@
 ---
-- hosts: localhost
-  gather_facts: no
-  connection: local
-  become: no
-  vars_files:
-  - vars.yml
-  - cluster_hosts.yml
-  tasks:
-  - set_fact:
-      g_ssh_user_tmp: "{{ deployment_vars[deployment_type].ssh_user }}"
-      g_sudo_tmp: "{{ deployment_vars[deployment_type].sudo }}"
-      g_etcd_hosts: "{{ etcd_hosts }}"
-      g_master_hosts: "{{ master_hosts }}"
-      g_node_hosts: "{{ node_hosts }}"
-      g_lb_hosts: "{{ lb_hosts }}"
-
 - include: ../../common/openshift-cluster/config.yml
+  vars_files:
+  - ../../aws/openshift-cluster/vars.yml
+  - ../../aws/openshift-cluster/cluster_hosts.yml
   vars:
-    g_etcd_hosts:   "{{ hostvars.localhost.g_etcd_hosts }}"
-    g_master_hosts: "{{ hostvars.localhost.g_master_hosts }}"
-    g_node_hosts:   "{{ hostvars.localhost.g_node_hosts }}"
-    g_lb_hosts:     "{{ hostvars.localhost.g_lb_hosts }}"
-    g_ssh_user: "{{ hostvars.localhost.g_ssh_user_tmp }}"
-    g_sudo: "{{ hostvars.localhost.g_sudo_tmp }}"
+    g_ssh_user: "{{ deployment_vars[deployment_type].ssh_user }}"
+    g_sudo: "{{ deployment_vars[deployment_type].sudo }}"
     g_nodeonmaster: true
     openshift_cluster_id: "{{ cluster_id }}"
-    openshift_debug_level: 2
+    openshift_debug_level: "{{ debug_level }}"
     openshift_deployment_type: "{{ deployment_type }}"
     openshift_hostname: "{{ ec2_private_ip_address }}"
     openshift_public_hostname: "{{ ec2_ip_address }}"

--- a/playbooks/aws/openshift-cluster/scaleup.yml
+++ b/playbooks/aws/openshift-cluster/scaleup.yml
@@ -6,16 +6,7 @@
   become: no
   vars_files:
   - vars.yml
-  - cluster_hosts.yml
   tasks:
-  - set_fact:
-      g_ssh_user_tmp: "{{ deployment_vars[deployment_type].ssh_user }}"
-      g_sudo_tmp: "{{ deployment_vars[deployment_type].sudo }}"
-      g_etcd_hosts: "{{ etcd_hosts }}"
-      g_master_hosts: "{{ master_hosts }}"
-      g_node_hosts: "{{ node_hosts }}"
-      g_lb_hosts: "{{ lb_hosts }}"
-
   - name: Evaluate oo_hosts_to_update
     add_host:
       name: "{{ item }}"
@@ -27,21 +18,16 @@
 - include: ../../common/openshift-cluster/update_repos_and_packages.yml
 
 - include: ../../common/openshift-cluster/scaleup.yml
+  vars_files:
+  - ../../aws/openshift-cluster/vars.yml
+  - ../../aws/openshift-cluster/cluster_hosts.yml
   vars:
-    g_etcd_hosts:   "{{ hostvars.localhost.g_etcd_hosts }}"
-    g_master_hosts: "{{ hostvars.localhost.g_master_hosts }}"
-    g_node_hosts:   "{{ hostvars.localhost.g_node_hosts }}"
-    g_lb_hosts:     "{{ hostvars.localhost.g_lb_hosts }}"
-    g_etcd_hosts: "{{ etcd_hosts }}"
-    g_lb_hosts: "{{ lb_hosts }}"
-    g_master_hosts: "{{ master_hosts }}"
-    g_node_hosts: "{{ node_hosts }}"
     g_new_node_hosts: "{{ groups.nodes_to_add }}"
-    g_ssh_user: "{{ hostvars.localhost.g_ssh_user_tmp }}"
-    g_sudo: "{{ hostvars.localhost.g_sudo_tmp }}"
+    g_ssh_user: "{{ deployment_vars[deployment_type].ssh_user }}"
+    g_sudo: "{{ deployment_vars[deployment_type].sudo }}"
     g_nodeonmaster: true
     openshift_cluster_id: "{{ cluster_id }}"
-    openshift_debug_level: 2
+    openshift_debug_level: "{{ debug_level }}"
     openshift_deployment_type: "{{ deployment_type }}"
     openshift_hostname: "{{ ec2_private_ip_address }}"
     openshift_public_hostname: "{{ ec2_ip_address }}"

--- a/playbooks/aws/openshift-cluster/update.yml
+++ b/playbooks/aws/openshift-cluster/update.yml
@@ -14,7 +14,7 @@
       groups: oo_hosts_to_update
       ansible_ssh_user: "{{ deployment_vars[deployment_type].ssh_user }}"
       ansible_sudo: "{{ deployment_vars[deployment_type].sudo }}"
-    with_items: "{{ master_hosts | union(node_hosts) | union(etcd_hosts) | default([]) }}"
+    with_items: "{{ g_all_hosts | default([]) }}"
 
 - include: ../../common/openshift-cluster/update_repos_and_packages.yml
 

--- a/playbooks/aws/openshift-cluster/upgrades/v3_0_to_v3_1/upgrade.yml
+++ b/playbooks/aws/openshift-cluster/upgrades/v3_0_to_v3_1/upgrade.yml
@@ -2,33 +2,16 @@
 # This playbook upgrades an existing AWS cluster, leaving nodes untouched if used with an 'online' deployment type.
 # Usage:
 #  ansible-playbook playbooks/aws/openshift-cluster/upgrades/v3_0_to_v3_1/upgrade.yml -e deployment_type=online -e cluster_id=<cluster_id>
-- hosts: localhost
-  gather_facts: no
-  vars_files:
-  - ../../vars.yml
-  - "../../vars.{{ deployment_type }}.{{ cluster_id }}.yml"
-  - ../../cluster_hosts.yml
-
-  tasks:
-  - set_fact:
-      g_ssh_user_tmp: "{{ deployment_vars[deployment_type].ssh_user }}"
-      g_sudo_tmp: "{{ deployment_vars[deployment_type].sudo }}"
-      g_etcd_hosts: "{{ etcd_hosts }}"
-      g_master_hosts: "{{ master_hosts }}"
-      g_node_hosts: "{{ node_hosts }}"
-      g_lb_hosts: "{{ lb_hosts }}"
-
 - include: ../../../../common/openshift-cluster/upgrades/v3_0_to_v3_1/upgrade.yml
+  vars_files:
+  - ../../../../aws/openshift-cluster/vars.yml
+  - ../../../../aws/openshift-cluster/cluster_hosts.yml
   vars:
-    g_etcd_hosts:   "{{ hostvars.localhost.g_etcd_hosts }}"
-    g_master_hosts: "{{ hostvars.localhost.g_master_hosts }}"
-    g_node_hosts:   "{{ hostvars.localhost.g_node_hosts }}"
-    g_lb_hosts:     "{{ hostvars.localhost.g_lb_hosts }}"
-    g_ssh_user: "{{ hostvars.localhost.g_ssh_user_tmp }}"
-    g_sudo: "{{ hostvars.localhost.g_sudo_tmp }}"
+    g_ssh_user: "{{ deployment_vars[deployment_type].ssh_user }}"
+    g_sudo: "{{ deployment_vars[deployment_type].sudo }}"
     g_nodeonmaster: true
     openshift_cluster_id: "{{ cluster_id }}"
-    openshift_debug_level: 2
+    openshift_debug_level: "{{ debug_level }}"
     openshift_deployment_type: "{{ deployment_type }}"
     openshift_hostname: "{{ ec2_private_ip_address }}"
     openshift_public_hostname: "{{ ec2_ip_address }}"

--- a/playbooks/aws/openshift-cluster/vars.yml
+++ b/playbooks/aws/openshift-cluster/vars.yml
@@ -1,4 +1,5 @@
 ---
+debug_level: 2
 deployment_vars:
   origin:
     # centos-7, requires marketplace

--- a/playbooks/byo/openshift-cluster/cluster_hosts.yml
+++ b/playbooks/byo/openshift-cluster/cluster_hosts.yml
@@ -3,9 +3,9 @@ g_etcd_hosts:   "{{ groups.etcd | default([]) }}"
 
 g_lb_hosts:     "{{ groups.lb | default([]) }}"
 
-g_master_hosts: "{{ groups.master | default([]) }}"
+g_master_hosts: "{{ groups.masters | default([]) }}"
 
-g_node_hosts:   "{{ groups.node | default([]) }}"
+g_node_hosts:   "{{ groups.nodes | default([]) }}"
 
 g_all_hosts:    "{{ g_master_hosts | union(g_node_hosts) | union(g_etcd_hosts)
                     | union(g_lb_hosts) | default([]) }}"

--- a/playbooks/byo/openshift-cluster/cluster_hosts.yml
+++ b/playbooks/byo/openshift-cluster/cluster_hosts.yml
@@ -1,0 +1,11 @@
+---
+g_etcd_hosts:   "{{ groups.etcd | default([]) }}"
+
+g_lb_hosts:     "{{ groups.lb | default([]) }}"
+
+g_master_hosts: "{{ groups.master | default([]) }}"
+
+g_node_hosts:   "{{ groups.node | default([]) }}"
+
+g_all_hosts:    "{{ g_master_hosts | union(g_node_hosts) | union(g_etcd_hosts)
+                    | union(g_lb_hosts) | default([]) }}"

--- a/playbooks/byo/openshift-cluster/config.yml
+++ b/playbooks/byo/openshift-cluster/config.yml
@@ -1,10 +1,8 @@
 ---
 - include: ../../common/openshift-cluster/config.yml
+  vars_files:
+  - ../../byo/openshift-cluster/cluster_hosts.yml
   vars:
-    g_etcd_hosts: "{{ groups.etcd | default([]) }}"
-    g_master_hosts: "{{ groups.masters | default([]) }}"
-    g_node_hosts: "{{ groups.nodes | default([]) }}"
-    g_lb_hosts: "{{ groups.lb | default([]) }}"
     openshift_cluster_id: "{{ cluster_id | default('default') }}"
-    openshift_debug_level: 2
+    openshift_debug_level: "{{ debug_level | default(2) }}"
     openshift_deployment_type: "{{ deployment_type }}"

--- a/playbooks/byo/openshift-cluster/scaleup.yml
+++ b/playbooks/byo/openshift-cluster/scaleup.yml
@@ -1,10 +1,8 @@
 ---
 - include: ../../common/openshift-cluster/scaleup.yml
+  vars_files:
+  - ../../byo/openshift-cluster/cluster_hosts.yml
   vars:
-    g_etcd_hosts: "{{ groups.etcd | default([]) }}"
-    g_master_hosts: "{{ groups.masters | default([]) }}"
-    g_new_node_hosts: "{{ groups.new_nodes | default([]) }}"
-    g_lb_hosts: "{{ groups.lb | default([]) }}"
     openshift_cluster_id: "{{ cluster_id | default('default') }}"
-    openshift_debug_level: 2
+    openshift_debug_level: "{{ debug_level | default(2) }}"
     openshift_deployment_type: "{{ deployment_type }}"

--- a/playbooks/byo/openshift-cluster/upgrades/v3_0_minor/upgrade.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/v3_0_minor/upgrade.yml
@@ -1,9 +1,7 @@
 ---
 - include: ../../../../common/openshift-cluster/upgrades/v3_0_minor/upgrade.yml
+  vars_files:
+  - ../../../../byo/openshift-cluster/cluster_hosts.yml
   vars:
-    g_etcd_hosts: "{{ groups.etcd | default([]) }}"
-    g_master_hosts: "{{ groups.masters | default([]) }}"
-    g_node_hosts: "{{ groups.nodes | default([]) }}"
-    g_lb_hosts: "{{ groups.lb | default([]) }}"
     openshift_cluster_id: "{{ cluster_id | default('default') }}"
     openshift_deployment_type: "{{ deployment_type }}"

--- a/playbooks/byo/openshift-cluster/upgrades/v3_0_to_v3_1/upgrade.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/v3_0_to_v3_1/upgrade.yml
@@ -1,9 +1,7 @@
 ---
 - include: ../../../../common/openshift-cluster/upgrades/v3_0_to_v3_1/upgrade.yml
+  vars_files:
+  - ../../../../byo/openshift-cluster/cluster_hosts.yml
   vars:
-    g_etcd_hosts: "{{ groups.etcd | default([]) }}"
-    g_master_hosts: "{{ groups.masters | default([]) }}"
-    g_node_hosts: "{{ groups.nodes | default([]) }}"
-    g_lb_hosts: "{{ groups.lb | default([]) }}"
     openshift_cluster_id: "{{ cluster_id | default('default') }}"
     openshift_deployment_type: "{{ deployment_type }}"

--- a/playbooks/gce/openshift-cluster/cluster_hosts.yml
+++ b/playbooks/gce/openshift-cluster/cluster_hosts.yml
@@ -1,16 +1,19 @@
 ---
-etcd_hosts:   "{{ (groups['tag_host-type-etcd']|default([]))
-                   | intersect((groups['tag_clusterid-' ~ cluster_id]|default([])))
-                   | intersect((groups['tag_environment-' ~ cluster_env]|default([]))) }}"
+g_etcd_hosts:   "{{ (groups['tag_host-type-etcd']|default([]))
+                     | intersect((groups['tag_clusterid-' ~ cluster_id]|default([])))
+                     | intersect((groups['tag_environment-' ~ cluster_env]|default([]))) }}"
 
-lb_hosts:     "{{ (groups['tag_host-type-lb']|default([]))
-                   | intersect((groups['tag_clusterid-' ~ cluster_id]|default([])))
-                   | intersect((groups['tag_environment-' ~ cluster_env]|default([]))) }}"
+g_lb_hosts:     "{{ (groups['tag_host-type-lb']|default([]))
+                     | intersect((groups['tag_clusterid-' ~ cluster_id]|default([])))
+                     | intersect((groups['tag_environment-' ~ cluster_env]|default([]))) }}"
 
-master_hosts: "{{ (groups['tag_host-type-master']|default([]))
-                   | intersect((groups['tag_clusterid-' ~ cluster_id]|default([])))
-                   | intersect((groups['tag_environment-' ~ cluster_env]|default([]))) }}"
+g_master_hosts: "{{ (groups['tag_host-type-master']|default([]))
+                     | intersect((groups['tag_clusterid-' ~ cluster_id]|default([])))
+                     | intersect((groups['tag_environment-' ~ cluster_env]|default([]))) }}"
 
-node_hosts:   "{{ (groups['tag_host-type-node']|default([]))
-                   | intersect((groups['tag_clusterid-' ~ cluster_id]|default([])))
-                   | intersect((groups['tag_environment-' ~ cluster_env]|default([]))) }}"
+g_node_hosts:   "{{ (groups['tag_host-type-node']|default([]))
+                     | intersect((groups['tag_clusterid-' ~ cluster_id]|default([])))
+                     | intersect((groups['tag_environment-' ~ cluster_env]|default([]))) }}"
+
+g_all_hosts:    "{{ g_master_hosts | union(g_node_hosts) | union(g_etcd_hosts)
+                    | union(g_lb_hosts) | default([]) }}"

--- a/playbooks/gce/openshift-cluster/config.yml
+++ b/playbooks/gce/openshift-cluster/config.yml
@@ -2,36 +2,17 @@
 # TODO: fix firewall related bug with GCE and origin, since GCE is overriding
 # /etc/sysconfig/iptables
 
-- hosts: localhost
-  gather_facts: no
-  connection: local
-  become: no
-  vars_files:
-  - vars.yml
-  - cluster_hosts.yml
-  tasks:
-  - set_fact:
-      g_etcd_hosts: "{{ etcd_hosts }}"
-      g_master_hosts: "{{ master_hosts }}"
-      g_node_hosts: "{{ node_hosts }}"
-      g_lb_hosts: "{{ lb_hosts }}"
-      g_ssh_user_tmp: "{{ deployment_vars[deployment_type].ssh_user }}"
-      g_sudo_tmp: "{{ deployment_vars[deployment_type].sudo }}"
-      use_sdn: "{{ do_we_use_openshift_sdn }}"
-      sdn_plugin: "{{ sdn_network_plugin }}"
-
 - include: ../../common/openshift-cluster/config.yml
+  vars_files:
+  - ../../gce/openshift-cluster/vars.yml
+  - ../../gce/openshift-cluster/cluster_hosts.yml
   vars:
-    g_etcd_hosts:   "{{ hostvars.localhost.g_etcd_hosts }}"
-    g_master_hosts: "{{ hostvars.localhost.g_master_hosts }}"
-    g_node_hosts:   "{{ hostvars.localhost.g_node_hosts }}"
-    g_lb_hosts:     "{{ hostvars.localhost.g_lb_hosts }}"
-    g_ssh_user: "{{ hostvars.localhost.g_ssh_user_tmp }}"
-    g_sudo: "{{ hostvars.localhost.g_sudo_tmp }}"
+    g_ssh_user: "{{ deployment_vars[deployment_type].ssh_user }}"
+    g_sudo: "{{ deployment_vars[deployment_type].sudo }}"
     g_nodeonmaster: true
     openshift_cluster_id: "{{ cluster_id }}"
-    openshift_debug_level: 2
+    openshift_debug_level: "{{ debug_level }}"
     openshift_deployment_type: "{{ deployment_type }}"
     openshift_hostname: "{{ gce_private_ip }}"
-    openshift_use_openshift_sdn: "{{ hostvars.localhost.use_sdn  }}"
-    os_sdn_network_plugin_name: "{{ hostvars.localhost.sdn_plugin }}"
+    openshift_use_openshift_sdn: "{{ do_we_use_openshift_sdn }}"
+    os_sdn_network_plugin_name: "{{ sdn_network_plugin }}"

--- a/playbooks/gce/openshift-cluster/update.yml
+++ b/playbooks/gce/openshift-cluster/update.yml
@@ -1,8 +1,8 @@
 ---
 - name: Populate oo_hosts_to_update group
   hosts: localhost
-  become: no
   connection: local
+  become: no
   gather_facts: no
   vars_files:
   - vars.yml
@@ -14,7 +14,7 @@
       groups: oo_hosts_to_update
       ansible_ssh_user: "{{ deployment_vars[deployment_type].ssh_user | default(ansible_ssh_user, true) }}"
       ansible_sudo: "{{ deployment_vars[deployment_type].sudo }}"
-    with_items: "{{ master_hosts | union(node_hosts) | union(etcd_hosts) | default([]) }}"
+    with_items: "{{ g_all_hosts | default([]) }}"
 
 - include: ../../common/openshift-cluster/update_repos_and_packages.yml
 

--- a/playbooks/gce/openshift-cluster/vars.yml
+++ b/playbooks/gce/openshift-cluster/vars.yml
@@ -1,6 +1,7 @@
 ---
 do_we_use_openshift_sdn: true
-sdn_network_plugin: redhat/openshift-ovs-subnet 
+sdn_network_plugin: redhat/openshift-ovs-subnet
+debug_level: 2
 # os_sdn_network_plugin_name can be ovssubnet or multitenant, see https://docs.openshift.org/latest/architecture/additional_concepts/sdn.html#ovssubnet-plugin-operation
 deployment_vars:
   origin:

--- a/playbooks/libvirt/openshift-cluster/cluster_hosts.yml
+++ b/playbooks/libvirt/openshift-cluster/cluster_hosts.yml
@@ -1,16 +1,19 @@
 ---
-etcd_hosts:   "{{ (groups['tag_host-type-etcd']|default([]))
-                   | intersect((groups['tag_clusterid-' ~ cluster_id]|default([])))
-                   | intersect((groups['tag_environment-' ~ cluster_env]|default([]))) }}"
+g_etcd_hosts:   "{{ (groups['tag_host-type-etcd']|default([]))
+                     | intersect((groups['tag_clusterid-' ~ cluster_id]|default([])))
+                     | intersect((groups['tag_environment-' ~ cluster_env]|default([]))) }}"
 
-lb_hosts:     "{{ (groups['tag_host-type-lb']|default([]))
-                   | intersect((groups['tag_clusterid-' ~ cluster_id]|default([])))
-                   | intersect((groups['tag_environment-' ~ cluster_env]|default([]))) }}"
+g_lb_hosts:     "{{ (groups['tag_host-type-lb']|default([]))
+                     | intersect((groups['tag_clusterid-' ~ cluster_id]|default([])))
+                     | intersect((groups['tag_environment-' ~ cluster_env]|default([]))) }}"
 
-master_hosts: "{{ (groups['tag_host-type-master']|default([]))
-                   | intersect((groups['tag_clusterid-' ~ cluster_id]|default([])))
-                   | intersect((groups['tag_environment-' ~ cluster_env]|default([]))) }}"
+g_master_hosts: "{{ (groups['tag_host-type-master']|default([]))
+                     | intersect((groups['tag_clusterid-' ~ cluster_id]|default([])))
+                     | intersect((groups['tag_environment-' ~ cluster_env]|default([]))) }}"
 
-node_hosts:   "{{ (groups['tag_host-type-node']|default([]))
-                   | intersect((groups['tag_clusterid-' ~ cluster_id]|default([])))
-                   | intersect((groups['tag_environment-' ~ cluster_env]|default([]))) }}"
+g_node_hosts:   "{{ (groups['tag_host-type-node']|default([]))
+                     | intersect((groups['tag_clusterid-' ~ cluster_id]|default([])))
+                     | intersect((groups['tag_environment-' ~ cluster_env]|default([]))) }}"
+
+g_all_hosts:    "{{ g_master_hosts | union(g_node_hosts) | union(g_etcd_hosts)
+                    | union(g_lb_hosts) | default([]) }}"

--- a/playbooks/libvirt/openshift-cluster/config.yml
+++ b/playbooks/libvirt/openshift-cluster/config.yml
@@ -2,31 +2,14 @@
 # TODO: need to figure out a plan for setting hostname, currently the default
 # is localhost, so no hostname value (or public_hostname) value is getting
 # assigned
-
-- hosts: localhost
-  gather_facts: no
-  become: no
-  connection: local
-  vars_files:
-  - vars.yml
-  - cluster_hosts.yml
-  tasks:
-  - set_fact:
-      g_ssh_user_tmp: "{{ deployment_vars[deployment_type].ssh_user }}"
-      g_sudo_tmp: "{{ deployment_vars[deployment_type].sudo }}"
-      g_etcd_hosts: "{{ etcd_hosts }}"
-      g_master_hosts: "{{ master_hosts }}"
-      g_node_hosts: "{{ node_hosts }}"
-      g_lb_hosts: "{{ lb_hosts }}"
-
 - include: ../../common/openshift-cluster/config.yml
+  vars_files:
+  - ../../libvirt/openshift-cluster/vars.yml
+  - ../../libvirt/openshift-cluster/cluster_hosts.yml
   vars:
-    g_etcd_hosts:   "{{ hostvars.localhost.g_etcd_hosts }}"
-    g_master_hosts: "{{ hostvars.localhost.g_master_hosts }}"
-    g_node_hosts:   "{{ hostvars.localhost.g_node_hosts }}"
-    g_lb_hosts:     "{{ hostvars.localhost.g_lb_hosts }}"
-    g_ssh_user: "{{ hostvars.localhost.g_ssh_user_tmp }}"
-    g_sudo: "{{ hostvars.localhost.g_sudo_tmp }}"
+    g_ssh_user: "{{ deployment_vars[deployment_type].ssh_user }}"
+    g_sudo: "{{ deployment_vars[deployment_type].sudo }}"
+    g_nodeonmaster: true
     openshift_cluster_id: "{{ cluster_id }}"
-    openshift_debug_level: 2
+    openshift_debug_level: "{{ debug_level }}"
     openshift_deployment_type: "{{ deployment_type }}"

--- a/playbooks/libvirt/openshift-cluster/update.yml
+++ b/playbooks/libvirt/openshift-cluster/update.yml
@@ -1,8 +1,8 @@
 ---
 - name: Populate oo_hosts_to_update group
   hosts: localhost
-  become: no
   connection: local
+  become: no
   gather_facts: no
   vars_files:
   - vars.yml
@@ -14,7 +14,7 @@
       groups: oo_hosts_to_update
       ansible_ssh_user: "{{ deployment_vars[deployment_type].ssh_user }}"
       ansible_sudo: "{{ deployment_vars[deployment_type].sudo }}"
-    with_items: "{{ master_hosts  | union(node_hosts) | union(etcd_hosts) | default([]) }}"
+    with_items: "{{ g_all_hosts | default([]) }}"
 
 - include: ../../common/openshift-cluster/update_repos_and_packages.yml
 

--- a/playbooks/libvirt/openshift-cluster/vars.yml
+++ b/playbooks/libvirt/openshift-cluster/vars.yml
@@ -3,6 +3,7 @@ libvirt_storage_pool_path: "{{ lookup('env','HOME') }}/libvirt-storage-pool-open
 libvirt_storage_pool: 'openshift-ansible'
 libvirt_network: openshift-ansible
 libvirt_uri: 'qemu:///system'
+debug_level: 2
 
 deployment_vars:
   origin:

--- a/playbooks/openstack/openshift-cluster/cluster_hosts.yml
+++ b/playbooks/openstack/openshift-cluster/cluster_hosts.yml
@@ -1,16 +1,19 @@
 ---
-etcd_hosts:   "{{ (groups['tag_host-type_etcd']|default([])
-                   | intersect((groups['tag_clusterid_' ~ cluster_id]|default([])))
-                   | intersect((groups['tag_environment_' ~ cluster_env]|default([]))) }}"
+g_etcd_hosts:   "{{ (groups['tag_host-type_etcd']|default([]))
+                     | intersect((groups['tag_clusterid_' ~ cluster_id]|default([])))
+                     | intersect((groups['tag_environment_' ~ cluster_env]|default([]))) }}"
 
-lb_hosts:     "{{ (groups['tag_host-type_lb']|default([]))
-                   | intersect((groups['tag_clusterid_' ~ cluster_id]|default([])))
-                   | intersect((groups['tag_environment_' ~ cluster_env]|default([]))) }}"
+g_lb_hosts:     "{{ (groups['tag_host-type_lb']|default([]))
+                     | intersect((groups['tag_clusterid_' ~ cluster_id]|default([])))
+                     | intersect((groups['tag_environment_' ~ cluster_env]|default([]))) }}"
 
-master_hosts: "{{ (groups['tag_host-type_master']|default([]))
-                   | intersect((groups['tag_clusterid_' ~ cluster_id]|default([])))
-                   | intersect((groups['tag_environment_' ~ cluster_env]|default([]))) }}"
+g_master_hosts: "{{ (groups['tag_host-type_master']|default([]))
+                     | intersect((groups['tag_clusterid_' ~ cluster_id]|default([])))
+                     | intersect((groups['tag_environment_' ~ cluster_env]|default([]))) }}"
 
-node_hosts:   "{{ (groups['tag_host-type_node']|default([]))
-                   | intersect((groups['tag_clusterid_' ~ cluster_id]|default([])))
-                   | intersect((groups['tag_environment_' ~ cluster_env]|default([]))) }}"
+g_node_hosts:   "{{ (groups['tag_host-type_node']|default([]))
+                     | intersect((groups['tag_clusterid_' ~ cluster_id]|default([])))
+                     | intersect((groups['tag_environment_' ~ cluster_env]|default([]))) }}"
+
+g_all_hosts:    "{{ g_master_hosts | union(g_node_hosts) | union(g_etcd_hosts)
+                    | union(g_lb_hosts) | default([]) }}"

--- a/playbooks/openstack/openshift-cluster/config.yml
+++ b/playbooks/openstack/openshift-cluster/config.yml
@@ -1,29 +1,13 @@
-- hosts: localhost
-  gather_facts: no
-  become: no
-  connection: local
-  vars_files:
-  - vars.yml
-  - cluster_hosts.yml
-  tasks:
-  - set_fact:
-      g_ssh_user_tmp: "{{ deployment_vars[deployment_type].ssh_user }}"
-      g_sudo_tmp: "{{ deployment_vars[deployment_type].sudo }}"
-      g_etcd_hosts:   "{{ etcd_hosts }}"
-      g_lb_hosts:     "{{ lb_hosts }}"
-      g_master_hosts: "{{ master_hosts }}"
-      g_node_hosts:   "{{ node_hosts }}"
-
-
+---
 - include: ../../common/openshift-cluster/config.yml
+  vars_files:
+  - ../../openstack/openshift-cluster/vars.yml
+  - ../../openstack/openshift-cluster/cluster_hosts.yml
   vars:
-    g_etcd_hosts:   "{{ hostvars.localhost.g_etcd_hosts }}"
-    g_lb_hosts:   "{{ hostvars.localhost.g_lb_hosts }}"
-    g_master_hosts:   "{{ hostvars.localhost.g_master_hosts }}"
-    g_node_hosts:   "{{ hostvars.localhost.g_node_hosts }}"
-    g_ssh_user: "{{ hostvars.localhost.g_ssh_user_tmp }}"
-    g_sudo: "{{ hostvars.localhost.g_sudo_tmp }}"
+    g_ssh_user: "{{ deployment_vars[deployment_type].ssh_user }}"
+    g_sudo: "{{ deployment_vars[deployment_type].sudo }}"
+    g_nodeonmaster: true
     openshift_cluster_id: "{{ cluster_id }}"
-    openshift_debug_level: 2
+    openshift_debug_level: "{{ debug_level }}"
     openshift_deployment_type: "{{ deployment_type }}"
     openshift_hostname: "{{ ansible_default_ipv4.address }}"

--- a/playbooks/openstack/openshift-cluster/update.yml
+++ b/playbooks/openstack/openshift-cluster/update.yml
@@ -1,8 +1,8 @@
 ---
 - name: Populate oo_hosts_to_update group
   hosts: localhost
-  become: no
   connection: local
+  become: no
   gather_facts: no
   vars_files:
   - vars.yml
@@ -14,7 +14,7 @@
       groups: oo_hosts_to_update
       ansible_ssh_user: "{{ deployment_vars[deployment_type].ssh_user }}"
       ansible_sudo: "{{ deployment_vars[deployment_type].sudo }}"
-    with_items: "{{ master_hosts | union(node_hosts) | union(etcd_hosts) | default([]) }}"
+    with_items: "{{ g_all_hosts | default([]) }}"
 
 - include: ../../common/openshift-cluster/update_repos_and_packages.yml
 

--- a/playbooks/openstack/openshift-cluster/vars.yml
+++ b/playbooks/openstack/openshift-cluster/vars.yml
@@ -1,4 +1,5 @@
 ---
+debug_level: 2
 openstack_infra_heat_stack:     "{{ lookup('oo_option', 'infra_heat_stack' ) |
                                     default('files/heat_stack.yaml',         True) }}"
 openstack_network_cidr:         "{{ lookup('oo_option', 'net_cidr'         ) |


### PR DESCRIPTION
- Move debug_level into vars.yml and byo inventory
- change variables in cluster_hosts.yml to be g_\* and update playbooks to use
  those values directly instead of setting them indirectly
- added a new g_all_hosts entry in cluster_hosts to use in the update playbook
  instead of unioning all host types within the playbook
- added a cluster_hosts.yml for the byo playbook
