### PR TITLE
Added ability to copy managed disks into storageaccount/container/vhd

### DIFF
--- a/playbooks/azure/openshift-cluster/copy_and_create_offer.yml
+++ b/playbooks/azure/openshift-cluster/copy_and_create_offer.yml
@@ -1,0 +1,15 @@
+#!/usr/bin/ansible-playbook
+---
+- hosts: localhost
+  gather_facts: no
+  tasks:
+  - import_role:
+      name: openshift_azure
+      tasks_from: copy_md_to_vhd
+
+  - import_role:
+      name: openshift_azure
+      tasks_from: create_offer
+    vars:
+      openshift_azure_templ_os_vhd_url: "{{ openshift_azure_sas_urls[0] }}"
+      openshift_azure_templ_data_vhd_url: "{{ openshift_azure_sas_urls[1] }}"

--- a/playbooks/azure/openshift-cluster/copy_md_to_vhd.yml
+++ b/playbooks/azure/openshift-cluster/copy_md_to_vhd.yml
@@ -1,0 +1,8 @@
+#!/usr/bin/ansible-playbook
+---
+- hosts: localhost
+  gather_facts: no
+  tasks:
+  - import_role:
+      name: openshift_azure
+      tasks_from: copy_md_to_vhd.yml

--- a/roles/lib_utils/filter_plugins/openshift_azure_filters.py
+++ b/roles/lib_utils/filter_plugins/openshift_azure_filters.py
@@ -1,0 +1,96 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# pylint: disable=too-many-lines
+"""
+Custom filters for use in openshift_azure role.
+"""
+
+import json
+import urllib
+import urlparse
+from dateutil.parser import parse as date_parse
+from datetime import datetime, timedelta
+
+from ansible import errors
+from collections import Mapping
+
+def openshift_azure_convert_list_to_json(sas_data_list):
+    """ Receives a list of stdout sas data objects
+        Ex: "{{ sas_urls | openshift_azure_convert_list_to_json }}"
+    """
+    if not sas_data_list:
+        raise errors.AnsibleFilterError("|failed expects sas_data to be set")
+
+    if not isinstance(sas_data_list, list):
+        raise errors.AnsibleFilterError("|openshift_azure_convert_list_to_json failed expects to filter on a list object")
+
+    results = []
+    for res in sas_data_list:
+        results.append(json.loads(res))
+
+    return results
+
+
+#def openshift_azure_create_sas_url(sas_data):
+#    """ Receive a sas data object and create a url with the correct format
+#        Ex: "{{ sas_url | openshift_azure_create_sas_url }}"
+#
+#       {u'accessSas': u'https://md-2tptr3fghtb1.blob.core.windows.net/rrtwhl0vtlz3/abcd?sv=2017-04-17&sr=b&si=4541bd08-d6a4-4acf-be0f-89e232452c48&sig=M%2BLLV6qZaauAAk7qouLv1CiyjWFxGQiChVefTJcq7YI%3D',
+#        u'additionalProperties': {u'endTime': u'2018-03-26T17:01:30.7660035+00:00',
+#                                  u'name': u'fcf5dcbf-527f-4ca7-893a-e4d3086df4be',
+#                                  u'startTime': u'2018-03-26T17:01:30.2660012+00:00',
+#                                  u'status': u'Succeeded'}}
+#
+#    """
+#    if not sas_data:
+#        raise errors.AnsibleFilterError("|failed expects sas_data to be set")
+#
+#    if not isinstance(sas_data, list):
+#        raise errors.AnsibleFilterError("|openshift_azure_create_sas_url failed expects to filter on a list object")
+#
+#    # https://docs.microsoft.com/en-us/azure/storage/common/storage-dotnet-shared-access-signature-part-1#examples-of-sas-uris
+#    # start time
+#    # sig = ''  signature
+#    # sr = ''  resource (b = blob, c = container)
+#    # sp = ''  permissions (r = read, w = write)
+#    # sv = ''  service version
+#
+#    # found in additional properties
+#    # "name": "name",  # not sure where this goes?
+#    #sas_additional_params = {"st": "startTime",
+#                             #"se": "endTime"}
+#
+#    results = []
+#    for sas in sas_data:
+#        url_parts = urlparse.urlparse(sas['accessSas'])
+#        qstring = urlparse.parse_qs(url_parts[4])
+#
+#        qstring['sp'] = ['rl']
+#        qstring['sr'] = ['c']
+#
+#        # start day is today - 1 day
+#        timestr = '%Y-%m-%dT00:00:00Z'
+#        start_time = date_parse(sas['additionalProperties']['startTime']) - timedelta(days=1)
+#        end_time = date_parse(sas['additionalProperties']['endTime']) + timedelta(days=8)
+#        qstring['st'] = [start_time.strftime(timestr)]
+#        qstring['se'] = [end_time.strftime(timestr)]
+#
+#        encoded = urllib.urlencode(qstring, doseq=True)
+#
+#        sas['accessSas'] = urlparse.urlunparse((url_parts.scheme, url_parts.netloc, url_parts.path,
+#                                                url_parts.params, encoded, url_parts.fragment))
+#
+#        results.append(sas)
+#    return sas_data
+
+
+class FilterModule(object):
+    """ Custom ansible filter mapping """
+
+    # pylint: disable=no-self-use, too-few-public-methods
+    def filters(self):
+        """ returns a mapping of filters to methods """
+        return {
+            #"openshift_azure_create_sas_url": openshift_azure_create_sas_url,
+            "openshift_azure_convert_list_to_json": openshift_azure_convert_list_to_json,
+        }

--- a/roles/openshift_azure/defaults/main.yml
+++ b/roles/openshift_azure/defaults/main.yml
@@ -104,6 +104,7 @@ openshift_azure_acsengine_template_edits: []
 
 # image publishing variables
 # openshift_azure_offer:
+openshift_azure_offer_force: False
 
 # offer template params #
 # openshift_azure_templ_display_text:
@@ -130,6 +131,7 @@ openshift_azure_acsengine_template_edits: []
 # openshift_azure_templ_os_type:
 # openshift_azure_templ_description:
 # openshift_azure_templ_summary:
+# openshift_azure_templ_marketing_url_id:
 # openshift_azure_templ_data_vhd_url:
 # openshift_azure_templ_os_vhd_url:
 # openshift_azure_templ_version:

--- a/roles/openshift_azure/tasks/copy_md_to_vhd.yml
+++ b/roles/openshift_azure/tasks/copy_md_to_vhd.yml
@@ -1,0 +1,117 @@
+---
+- debug:
+    msg: "{{ openshift_azure_vm_name }}"
+    verbosity: 1
+
+- name: find the disk
+  azure_rm_managed_disk_facts:
+    resource_group: "{{ openshift_azure_resource_group_name }}"
+    name: "{{ item }}"
+  register: diskout
+  with_items:
+  - "{{ openshift_azure_vm_name }}.vhd"
+  - "{{ openshift_azure_vm_name }}-datadisk-0"
+
+- name: set the diskid as a fact
+  set_fact:
+    l_managed_disk_ids: "{{ diskout | json_query('results[*].ansible_facts.azure_managed_disk[0].id') }}"
+
+- debug:
+    msg: "{{ l_managed_disk_ids }}"
+    verbosity: 1
+
+- name: create a SAS url
+  command: "az disk grant-access --ids {{ item }} --duration-in-seconds 3600 --output=json"
+  register: grantout
+  with_items: "{{ l_managed_disk_ids }}"
+
+- debug:
+    var: grantout
+    verbosity: 1
+
+- name: parse json and set sas_data_list
+  set_fact:
+    l_sas_data_list: "{{ grantout | json_query('results[*].stdout') | openshift_azure_convert_list_to_json }}"
+
+- debug:
+    var: l_sas_data_list
+    verbosity: 1
+
+# currently storage account calls do not return the connection string
+# https://github.com/ansible/ansible/issues/37934
+# - name: fetch connection string for storage account
+#  azure_rm_storageaccount_facts:
+#    resource_group: "{{ openshift_azure_resource_group_name }}"
+#    name: "{{ openshift_azure_storage_account_name }}"
+#  register: storageout
+- name: fetch the connection string
+  command: "az storage account show-connection-string --name {{ openshift_azure_storage_account_name }} --resource-group {{ openshift_azure_resource_group_name }} --output=json"
+  register: sa_conn
+
+- name: pick out the connection string
+  set_fact:
+    l_connection_string: "{{ sa_conn.stdout | from_json | json_query('connectionString') }}"
+
+- debug:
+    var: l_connection_string
+    verbosity: 1
+
+# this doesn't currently support uploading a disk from a SAS url
+#- name: copy blob from managed disk to storage account
+#  azure_rm_storageblob:
+#    resource_group: "{{ openshift_azure_resource_group_name }}"
+#    storage_account_name: "{{ openshift_azure_storage_account_name }}"
+#    container: "{{ openshift_azure_storage_account_container }}"
+#    #dest: "{{ openshift_azure_vm_name }}.vhd"
+#    blob: "{{ openshift_azure_vm_name }}.vhd"
+#    src: "{{ l_sas_data_list.accessSas }}"
+#  register: blobout
+#
+#- debug: var=blobout
+
+- name: copy the vhd to a blob
+  command: "az storage blob copy start --destination-blob {{ item.name }} --destination-container {{ openshift_azure_storage_account_container }} --connection-string {{ l_connection_string }} --source-uri {{ item.sas }} --output=json"
+  register: copyout
+  with_items:
+  - name: "{{ openshift_azure_vm_name }}.vhd"
+    sas: "{{ l_sas_data_list[0].accessSas }}"
+  - name: "{{ openshift_azure_vm_name }}-datadisk-0.vhd"
+    sas: "{{ l_sas_data_list[1].accessSas }}"
+  async: 600
+  poll: 0
+
+- name: check status of copy
+  command: "az storage blob show --name {{ item }} --container-name {{ openshift_azure_storage_account_container }} --connection-string '{{ l_connection_string }}' --output=json"
+  register: copystatus
+  with_items:
+  - "{{ openshift_azure_vm_name }}.vhd"
+  - "{{ openshift_azure_vm_name }}-datadisk-0.vhd"
+  until: copystatus.stdout | from_json | json_query('properties.copy.status') == 'success'
+  retries: 60
+  delay: 30
+
+- name: set start and expire dates
+  set_fact:
+    sas_expire: "{{ lookup('pipe', 'date -d \"14 days\" +\"%Y-%m-%dT%H:%M:00Z\"') }}"
+    sas_start: "{{ lookup('pipe', 'date -d \"3 days ago\" +\"%Y-%m-%dT%H:%M:00Z\"') }}"
+    disks:
+    - "{{ openshift_azure_vm_name }}.vhd"
+    - "{{ openshift_azure_vm_name }}-datadisk-0.vhd"
+
+- name: generate sas url for the container
+  command: |
+    az storage container generate-sas --name {{ openshift_azure_storage_account_container }} --account-name {{ openshift_azure_storage_account_name }} --permissions rl --expiry {{ sas_expire }} --start {{ sas_start }} --output=json
+  register: sasurl
+
+- debug:
+    var: sasurl
+    verbosity: 1
+
+- name: set the sas URLS
+  set_fact:
+    openshift_azure_sas_urls: "{{ openshift_azure_sas_urls|default([]) + ['https://' + openshift_azure_storage_account_name + '.blob.core.windows.net/' + openshift_azure_storage_account_container + '/' + item + '?' + sasurl.stdout|from_json] }}"
+  loop: "{{ disks }}"
+
+- debug:
+    var: openshift_azure_sas_urls
+    verbosity: 1

--- a/roles/openshift_azure/tasks/create_offer.yml
+++ b/roles/openshift_azure/tasks/create_offer.yml
@@ -1,5 +1,28 @@
 ---
+- name: fetch the current offer and update the versions
+  oo_azure_rm_publish_image_facts:
+    offer: "{{ openshift_azure_offer }}"
+  register: offerout
+
+- debug:
+    msg: "{{ offerout['data']['definition']['plans'][0]['microsoft-azure-virtualmachines.vmImages'] }}"
+    verbosity: 1
+
+- name: bring along the previous offer versions and combine with incoming
+  yedit:
+    content: "{{ lookup('template', 'offer.yml.j2') }}"
+    key: "definition#plans[0]#microsoft-azure-virtualmachines.vmImages#{{ item.key }}"
+    value: "{{ item.value }}"
+    separator: '#'
+  with_dict: "{{ offerout['data']['definition']['plans'][0]['microsoft-azure-virtualmachines.vmImages'] }}"
+  register: yeditout
+
+- debug:
+    var: yeditout
+    verbosity: 1
+
 - name: create an offer in cloudpartner portal
   oo_azure_rm_publish_image:
     offer: "{{ openshift_azure_offer }}"
     offer_data: "{{ lookup('template', 'offer.yml.j2') | from_yaml }}"
+    force: "{{ openshift_azure_offer_force }}"

--- a/roles/openshift_azure/templates/offer.yml.j2
+++ b/roles/openshift_azure/templates/offer.yml.j2
@@ -3,7 +3,7 @@ definition:
   offer:
     microsoft-azure-marketplace-testdrive.enabled: false
     microsoft-azure-marketplace-testdrive.videos: []
-    microsoft-azure-marketplace.allowedSubscriptions: {{ openshift_azure_templ_allowed_subscriptions }}
+    microsoft-azure-marketplace.allowedSubscriptions: {{ openshift_azure_templ_allowed_subscriptions | to_json }}
     microsoft-azure-marketplace.blobLeadConfiguration: {}
     microsoft-azure-marketplace.categories: [appInfrastructure]
     microsoft-azure-marketplace.crmLeadConfiguration: {}
@@ -21,7 +21,7 @@ definition:
     microsoft-azure-marketplace.mediumLogo: "{{ openshift_azure_templ_medium_logo }}"
     microsoft-azure-marketplace.smallLogo: "{{ openshift_azure_templ_small_logo }}"
     microsoft-azure-marketplace.wideLogo: "{{ openshift_azure_templ_wide_logo }}"
-    microsoft-azure-marketplace.offerMarketingUrlIdentifier: {{ openshift_azure_templ_offer_id }}
+    microsoft-azure-marketplace.offerMarketingUrlIdentifier: {{ openshift_azure_templ_marketing_url_id }}
     microsoft-azure-marketplace.privacyURL: "{{ openshift_azure_templ_privacy_url }}"
     microsoft-azure-marketplace.publicAzureSupportUrl: ''
     microsoft-azure-marketplace.salesForceLeadConfiguration: {}
@@ -45,7 +45,7 @@ definition:
     microsoft-azure-virtualmachines.operationSystem: {{ openshift_azure_templ_os }}
     microsoft-azure-virtualmachines.osType: {{ openshift_azure_templ_os_type }}
     microsoft-azure-virtualmachines.recommendedVMSizes: [ds3-standard-v2]
-    microsoft-azure-virtualmachines.skuDescription: {{ openshift_azure_templ_description }}
+    microsoft-azure-virtualmachines.skuDescription: {{ openshift_azure_templ_sku_description }}
     microsoft-azure-virtualmachines.skuSummary: {{ openshift_azure_templ_summary }}
     microsoft-azure-virtualmachines.skuTitle: {{ openshift_azure_templ_title }}
     microsoft-azure-virtualmachines.vmImages: {{ openshift_azure_templ_vm_images | from_yaml}}


### PR DESCRIPTION
I received the instructions from Harold at MS (@haroldwongms) to copy our managed disks into the storage account.  This script essentially does that process.  Once in the storage account they can be published.  Harold was able to publish the image after they were copied.

This is a first pass and can be improved with data verification or validation of the copy.

~~It would also be great if Harold or Boris can assist in automating the publishing process.~~