### PR TITLE
Azure updates for launch, origin, and image building.

### DIFF
--- a/playbooks/azure/openshift-cluster/build_base_image.yml
+++ b/playbooks/azure/openshift-cluster/build_base_image.yml
@@ -28,6 +28,12 @@
   - name: lay down yum certs which will be removed later
     import_tasks: tasks/yum_certs.yml
 
+  - name: enable networkmnager
+    lineinfile:
+      path: /etc/sysconfig/network-scripts/ifcfg-eth0
+      regexp: '^NM_CONTROLLED='
+      line: 'NM_CONTROLLED=yes'
+
   - name: update the /var partition with grpquota
     mount:
       boot: yes

--- a/playbooks/azure/openshift-cluster/build_image.yml
+++ b/playbooks/azure/openshift-cluster/build_image.yml
@@ -8,6 +8,10 @@
   hosts: localhost
   gather_facts: yes
   tasks:
+  - name: set the bootstrap fact
+    set_fact:
+      openshift_node_bootstrap: True
+
   - name: provision instance
     import_role:
       name: openshift_azure

--- a/roles/openshift_azure/defaults/main.yml
+++ b/roles/openshift_azure/defaults/main.yml
@@ -90,3 +90,12 @@ openshift_azure_subscription_id: "{{ lookup('ini', 'subscription_id section=defa
 openshift_azure_client_id: "{{ lookup('ini', 'client_id section=default file=' + openshift_azure_credentials_file) }}"
 openshift_azure_service_secret: "{{ lookup('ini', 'secret section=default file=' + openshift_azure_credentials_file) }}"
 openshift_azure_tenant_id: "{{ lookup('ini', 'tenant section=default file=' + openshift_azure_credentials_file) }}"
+
+# used in launch.yml for the openshift.json
+openshift_azure_acsengine_urls: []
+
+openshift_azure_acsengine_template_dns_prefix: "{{ openshift_azure_prefix }}-{{ openshift_azure_clusterid }}"
+openshift_azure_acsengine_template_image_name: "{{ openshift_azure_image }}"
+openshift_azure_acsengine_template_image_rg: "{{ openshift_azure_base_image_ns }}"
+
+openshift_azure_acsengine_template_edits: []

--- a/roles/openshift_azure/tasks/create_vm.yml
+++ b/roles/openshift_azure/tasks/create_vm.yml
@@ -1,8 +1,4 @@
 ---
-- name: set openshift_node_bootstrap to True when building AMI
-  set_fact:
-    openshift_node_bootstrap: True
-
 - name: Create virtual machine
   azure_rm_virtualmachine:
     resource_group: "{{ openshift_azure_resource_group_name }}"
@@ -39,4 +35,4 @@
 - name: Wait for SSH
   wait_for_connection:
   delegate_to: '{{ item }}'
-  with_items: '{{ groups["azure"] }}'
+  with_items: '{{ groups["nodes"] }}'

--- a/roles/openshift_azure/tasks/launch.yml
+++ b/roles/openshift_azure/tasks/launch.yml
@@ -18,6 +18,10 @@
     src: "{{ tmpout.path }}/openshift.json"
     edits: "{{ openshift_azure_acsengine_template_edits }}"
 
+- debug:
+    msg: "{{ lookup('file', tmpout.path ~ '/openshift.json') | from_json }}"
+    verbosity: 1
+
 - name: launch an acs-engine build
   command: |
     {{ tmpout.path }}/acs-engine deploy \


### PR DESCRIPTION
- Network manager fix was for origin.
- Moved openshift_node_bootstrap from the create_vm.yml and into the build_image.yml
- debug openshift.json file (@pschiffe please look at this.  This dumps important information but might leak info into logs)  Not sure how to handle this unless we get systematic about what we print.
- changed back to `nodes` instead of `azure` as it picks up every host in a resource group and we only want the most recently created vm.

